### PR TITLE
[EX] Releases ex-v0.9.3

### DIFF
--- a/impl/ex/mix.exs
+++ b/impl/ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Predicator.Mixfile do
   @name "Predicator"
   @app :predicator
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
-  @version "0.9.2"
+  @version "0.9.3"
 
   @deps [
     # Required


### PR DESCRIPTION
This adds a clause to evaluate 'nil > 1' (for any number) as false.